### PR TITLE
Bilder bei Einschaltvorgängen verkleinert

### DIFF
--- a/elektrotechnik/subsections/einschalt_kondensator.tex
+++ b/elektrotechnik/subsections/einschalt_kondensator.tex
@@ -1,7 +1,7 @@
 \begin{tabular}{ccc}
-	\includegraphics[width=6cm]{./idiotenseite/images/schaltung_C.png} &
-	\includegraphics[width=6cm]{./idiotenseite/images/uKond.png} &
-	\includegraphics[width=6cm]{./idiotenseite/images/iKond.png}\\
+	\includegraphics[width=5.5cm]{./idiotenseite/images/schaltung_C.png} &
+	\includegraphics[width=5.5cm]{./idiotenseite/images/uKond.png} &
+	\includegraphics[width=5.5cm]{./idiotenseite/images/iKond.png}\\
 \end{tabular}
 Serieschaltung von Widerstand und Kondensator an einem Rechtecksignal $U_e$
 \begin{multicols}{2}		

--- a/elektrotechnik/subsections/einschalt_spule.tex
+++ b/elektrotechnik/subsections/einschalt_spule.tex
@@ -1,7 +1,7 @@
 \begin{tabular}{ccc} 
-	\includegraphics[width=6cm]{./idiotenseite/images/schaltung_spule.png} &
-	\includegraphics[width=6cm]{./idiotenseite/images/uSpule.png} &
-	\includegraphics[width=6cm]{./idiotenseite/images/iSpule.png}\\	
+	\includegraphics[width=5.5cm]{./idiotenseite/images/schaltung_spule.png} &
+	\includegraphics[width=5.5cm]{./idiotenseite/images/uSpule.png} &
+	\includegraphics[width=5.5cm]{./idiotenseite/images/iSpule.png}\\	
 \end{tabular}
 Serieschaltung von Widerstand und Spule an einem Rechtecksignal $U_e$
 \begin{multicols}{2}


### PR DESCRIPTION
Hallo

Ich habe im ELT-Teil die Bilder der Spulen- und Kondensator-Einschaltvorgänge verkleinert. So passt ein \section Titel mit auf die ELT-Seite

Grüsse
Hannes
