### PR TITLE
Ableitung von sin/cos

### DIFF
--- a/trigo/subsections/Ableitungen.tex
+++ b/trigo/subsections/Ableitungen.tex
@@ -1,0 +1,23 @@
+
+
+\subsection{Ableitungen}
+
+\begin{tikzpicture}
+	[	inner sep = 2mm,
+		sin/.style={rectangle,minimum width=1.2cm,minimum height=1cm,rounded corners=5pt,draw=black,top color=green!20!black!50},
+		abl/.style={rectangle}
+	]
+	\node at (1.5,0) (sin1) [sin] {$\sin$};
+	\node at (0,-1.5) (cos2) [sin] {$-\cos$};
+	\node at (1.5,-3) (sin2) [sin] {$-\sin$};
+	\node at (3,-1.5) (cos1) [sin] {$\cos$};
+	
+	\draw[thick,black,->] (sin1.east) .. controls +(right:1cm) and +(up:1cm) ..  (cos1.north)
+	node [pos=0.5,above](abl) {$\frac{d}{dx}$};
+	\draw[thick,black,->] (cos1.south) .. controls +(down:1cm) and +(right:1cm) .. (sin2.east)
+	node [pos=0.5,below](abl) {$\frac{d}{dx}$};
+	\draw[thick,black,->] (sin2.west) .. controls +(left:1cm) and +(down:1cm) .. (cos2.south)
+	node [pos=0.5,below](abl) {$\frac{d}{dx}$};
+	\draw[thick,black,->] (cos2.north) .. controls +(up:1cm) and +(left:1cm) .. (sin1.west)
+	node [pos=0.5,above](abl) {$\frac{d}{dx}$};
+\end{tikzpicture}

--- a/trigo/trigoInclude.tex
+++ b/trigo/trigoInclude.tex
@@ -14,4 +14,10 @@
 	
 	\input{idiotenseite/trigo/subsections/SummeDifferenzen}
 \end{multicols}
-\input{idiotenseite/trigo/subsections/Euler}
+
+\begin{minipage}{6cm}
+	\input{idiotenseite/trigo/subsections/Ableitungen}
+\end{minipage}
+\begin{minipage}{12cm}
+	\input{idiotenseite/trigo/subsections/Euler}
+\end{minipage}


### PR DESCRIPTION
Graphische Übersicht, wie sin/cos abgeleitet werden eingefügt. Hatte gerade neben den euler'schen Formeln Platz - vergrössert die Zusammenfassung also nicht.

Damit das Tikz-Zeug funktioniert muss _\usepackage{tikz}_ eingebunden werden. Würde es nicht Sinn machen, das gleich in den Header einzufügen?
